### PR TITLE
Fix processing T.let type mismatch messages when there are digits in module name

### DIFF
--- a/lib/rspec/sorbet/doubles.rb
+++ b/lib/rspec/sorbet/doubles.rb
@@ -21,7 +21,7 @@ module RSpec
       private
 
       INLINE_DOUBLE_REGEX =
-        /T.(?:let|cast): Expected type (?:T.(?<t_method>any|nilable|class_of)\()?(?<expected_types>[a-zA-Z:: ,]*)(\))?, got (?:type .* with value )?#<(?<double_type>Instance|Class|Object)?Double([\(]|[ ])(?<doubled_type>[a-zA-Z:: ,]*)(\))?/.freeze
+        /T.(?:let|cast): Expected type (?:T.(?<t_method>any|nilable|class_of)\()?(?<expected_types>[a-zA-Z0-9:: ,]*)(\))?, got (?:type .* with value )?#<(?<double_type>Instance|Class|Object)?Double([\(]|[ ])(?<doubled_type>[a-zA-Z0-9:: ,]*)(\))?/.freeze
 
       def inline_type_error_handler(error)
         case error

--- a/spec/lib/rspec/sorbet_spec.rb
+++ b/spec/lib/rspec/sorbet_spec.rb
@@ -61,6 +61,10 @@ module RSpec
         end
       end
 
+      module M123
+        class Animal; end
+      end
+      
       let(:my_instance_double) { instance_double(String) }
       let(:my_person) do
         Person.new('Sam', 'Giles')
@@ -70,6 +74,9 @@ module RSpec
       end
       let(:another_person) do
         instance_double(Person, full_name: 'Yasmin Collins')
+      end
+      let(:my_animal_double) do
+        instance_double(M123::Animal)
       end
     end
 
@@ -85,6 +92,8 @@ module RSpec
         expect { T.let(my_instance_double, Integer) }.to raise_error(TypeError)
         expect { Greeter.new(my_person_double).greet_others([my_person_double, another_person]) }
           .to raise_error(TypeError)
+        expect { T.let(my_animal_double, M123::Animal) }.to raise_error
+
         subject
         expect { Greeter.new(my_person).greet }.not_to raise_error
         expect { Greeter.new(my_person_double).greet }.not_to raise_error
@@ -98,6 +107,7 @@ module RSpec
         expect { T.let(my_instance_double, T.any(String, TrueClass)) }.not_to raise_error
         expect { T.let(my_instance_double, Integer) }.to raise_error(TypeError)
         expect { T.let(my_instance_double, T.any(Integer, Numeric)) }.to raise_error(TypeError)
+        expect { T.let(my_animal_double, M123::Animal) }.not_to raise_error
       end
     end
 


### PR DESCRIPTION
Currently processing T.let type mismatch errors fails when there is a digit in the module name.
Reproducible with `Aws::SESV2::Client` for example.
Changing the regular expression to match any digits in module names, fixes the problem.
