### PR TITLE
omit sorbet/ when building gem

### DIFF
--- a/rspec-sorbet.gemspec
+++ b/rspec-sorbet.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
-    f.match(%r{^spec/}) && !f.match(%r{^spec/support/factories/})
+    f.match(%r{^(sorbet|spec)/}) && !f.match(%r{^spec/support/factories/})
   end
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }


### PR DESCRIPTION
IIUC the `sorbet/` directory is not needed at run time. Removing it from the gem build reduces the gem size by 93% (from 196k to 14k). There's probably room to optimize further (the remaining non-`lib` directories are likely unnecessary).