### PR TITLE
Make 'sorbet' a development-only dependency

### DIFF
--- a/rspec-sorbet.gemspec
+++ b/rspec-sorbet.gemspec
@@ -22,11 +22,11 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'sorbet'
   spec.add_dependency 'sorbet-runtime'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rake', '>= 13.0'
   spec.add_development_dependency 'rspec', '>= 3.0'
+  spec.add_development_dependency 'sorbet'
 end


### PR DESCRIPTION
AFAICT, `sorbet` is not used in the runtime. However, as a runtime dependency, this means that `rspec-sorbet` can only be installed on platforms that `sorbet` supports (e.g. not windows or linux arm64).
