### PR TITLE
Adding call through to existing defined handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+1.9.0
+
+* Allow specification of a custom validation handler
+
 1.8.3
 
 * Make sorbet a development dependency

--- a/README.md
+++ b/README.md
@@ -34,3 +34,16 @@ RSpec::Sorbet.allow_doubles!
 ### `eq` matcher usage with `T::Struct`'s
 
 Using the [`eq` matcher](https://www.rubydoc.info/github/rspec/rspec-expectations/RSpec%2FMatchers:eq) to compare [`T::Struct`'s](https://sorbet.org/docs/tstruct) might not behave as you'd expect whereby two separate instances of the same struct class with identical attributes are not `==` out of the box. The standalone [sorbet-struct-comparable](https://github.com/tricycle/sorbet-struct-comparable) gem may be of interest if you are looking for a simple attribute based comparison that will help make the `eq` matcher behave as you expect.
+
+### Specifying a custom validation handler
+
+You can customise the handler of Sorbet validation errors if you so desire.
+
+
+```ruby
+def handler(signature, opts)
+  raise MyCustomException, "The options were #{opts}"
+end
+
+T::Configuration.call_validation_error_handler = handler
+```

--- a/lib/rspec/sorbet/version.rb
+++ b/lib/rspec/sorbet/version.rb
@@ -3,6 +3,6 @@
 
 module RSpec
   module Sorbet
-    VERSION = '1.8.3'
+    VERSION = '1.9.0'
   end
 end

--- a/spec/lib/rspec/sorbet_spec.rb
+++ b/spec/lib/rspec/sorbet_spec.rb
@@ -132,7 +132,7 @@ module RSpec
       end
 
       describe 'with an existing error handler' do
-        let(:handler) { proc {|_,_| } }
+        let(:handler) { proc {|_,_| raise ArgumentError, 'foo'} }
 
         before do
           T::Configuration.call_validation_error_handler  = handler
@@ -150,10 +150,8 @@ module RSpec
         end
 
         specify do
-          expect(handler).to receive(:call)
-         
           # Error is not rasied becasue handler is no-op
-          expect { PassthroughSig.new(123) }.not_to raise_error
+          expect { PassthroughSig.new(123) }.to raise_error ArgumentError, 'foo'
         end
 
       end

--- a/spec/lib/rspec/sorbet_spec.rb
+++ b/spec/lib/rspec/sorbet_spec.rb
@@ -150,7 +150,7 @@ module RSpec
         end
 
         specify do
-          # Error is not rasied becasue handler is no-op
+          # Checking to ensure the invalid calls rasies the error in the custom handler
           expect { PassthroughSig.new(123) }.to raise_error ArgumentError, 'foo'
         end
 

--- a/spec/lib/rspec/sorbet_spec.rb
+++ b/spec/lib/rspec/sorbet_spec.rb
@@ -131,6 +131,33 @@ module RSpec
         it_should_behave_like 'it allows an instance double'
       end
 
+      describe 'with an existing error handler' do
+        let(:handler) { proc {|_,_| } }
+
+        before do
+          T::Configuration.call_validation_error_handler  = handler
+          described_class.allow_doubles!
+        end
+
+
+        class PassthroughSig
+          extend T::Sig
+
+          sig { params(message: String).void }
+          def initialize(message)
+            @message = message
+          end
+        end
+
+        specify do
+          expect(handler).to receive(:call)
+         
+          # Error is not rasied becasue handler is no-op
+          expect { PassthroughSig.new(123) }.not_to raise_error
+        end
+
+      end
+
       describe 'class doubles' do
         extend T::Sig
 

--- a/spec/lib/rspec/sorbet_spec.rb
+++ b/spec/lib/rspec/sorbet_spec.rb
@@ -64,7 +64,7 @@ module RSpec
       module M123
         class Animal; end
       end
-      
+
       let(:my_instance_double) { instance_double(String) }
       let(:my_person) do
         Person.new('Sam', 'Giles')
@@ -150,7 +150,7 @@ module RSpec
         end
 
         specify do
-          # Checking to ensure the invalid calls rasies the error in the custom handler
+          # Checking to ensure the invalid calls raises the error in the custom handler
           expect { PassthroughSig.new(123) }.to raise_error ArgumentError, 'foo'
         end
 


### PR DESCRIPTION
Currently when an error is raised due to it being being a double, it always raises. Since sorbet allows configuration of the handler for application specific purposes this gem should call through to the existing defined handler so that can be tested correctly.