### PR TITLE
support T.nilable(T.class_of(...)) doubles

### DIFF
--- a/lib/rspec/sorbet/doubles.rb
+++ b/lib/rspec/sorbet/doubles.rb
@@ -23,7 +23,7 @@ module RSpec
       private
 
       INLINE_DOUBLE_REGEX =
-        /T.(?:let|cast): Expected type (?:T.(?<t_method>any|nilable|class_of)\()?(?<expected_types>[a-zA-Z0-9:: ,]*)(\))?, got (?:type .* with value )?#<(?<double_type>Instance|Class|Object)?Double([\(]|[ ])(?<doubled_type>[a-zA-Z0-9:: ,]*)(\))?/.freeze
+        /T.(?:let|cast): Expected type (?:T.(?<t_method>any|nilable|class_of)\()*(?<expected_types>[a-zA-Z0-9:: ,]*)(\))*, got (?:type .* with value )?#<(?<double_type>Instance|Class|Object)?Double([\(]|[ ])(?<doubled_type>[a-zA-Z0-9:: ,]*)(\))?/.freeze
 
 
       def handle_call_validation_error(signature, opts)

--- a/spec/lib/rspec/sorbet_spec.rb
+++ b/spec/lib/rspec/sorbet_spec.rb
@@ -171,11 +171,15 @@ module RSpec
           expect { T.let(class_double(Rectangle), Rectangle) }.to raise_error(TypeError)
           expect { T.let(Rectangle, T.class_of(Rectangle)) }.not_to raise_error
           expect { T.let(class_double(Rectangle), T.class_of(Rectangle)) }.to raise_error(TypeError)
+          expect { T.let(Rectangle, T.nilable(T.class_of(Rectangle))) }.not_to raise_error
+          expect { T.let(class_double(Rectangle), T.nilable(T.class_of(Rectangle))) }.to raise_error(TypeError)
           subject
           expect { T.let(Rectangle, Rectangle) }.to raise_error(TypeError)
           expect { T.let(class_double(Rectangle), Rectangle) }.to raise_error(TypeError)
           expect { T.let(Rectangle, T.class_of(Rectangle)) }.not_to raise_error
           expect { T.let(class_double(Rectangle), T.class_of(Rectangle)) }.not_to raise_error
+          expect { T.let(Rectangle, T.nilable(T.class_of(Rectangle))) }.not_to raise_error
+          expect { T.let(class_double(Rectangle), T.nilable(T.class_of(Rectangle))) }.not_to raise_error
         end
 
         specify 'method signatures' do


### PR DESCRIPTION
Pretty much, instead of supporting just 0 or 1 `T.{any,nilable,class_of}` with the `?` operator, we can now support 0 or _more_.

closes #18